### PR TITLE
Added zlib compression and fixed shard error 1003 on startup

### DIFF
--- a/src/Gateway/Connection.php
+++ b/src/Gateway/Connection.php
@@ -81,7 +81,7 @@ class Connection implements ConnectionInterface
                 return;
             }
 
-            $json = @inflate_add($this->inflate, $this->buffer);
+            $json = inflate_add($this->inflate, $this->buffer);
             $this->buffer = '';
 
             if ($json === false) {

--- a/src/Gateway/Connection.php
+++ b/src/Gateway/Connection.php
@@ -31,6 +31,7 @@ use Ratchet\RFC6455\Messaging\MessageInterface;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
 use React\Promise\PromiseInterface;
+use InflateContext;
 
 /**
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
@@ -58,7 +59,7 @@ class Connection implements ConnectionInterface
     private ShardInterface $shard;
 
     private string $buffer = '';
-    private $inflate;
+    private InflateContext|false $inflate;
 
     public function __construct(
         private LoopInterface $loop,

--- a/tests/Gateway/ConnectionTest.php
+++ b/tests/Gateway/ConnectionTest.php
@@ -472,7 +472,7 @@ class ConnectionTest extends MockeryTestCase
         $loop->shouldReceive('futureTick')
             ->once()
             ->with(Mockery::on(function ($callback) {
-                $callback(); // вызываем вручную
+                $callback();
                 return true;
             }));
 

--- a/tests/Gateway/ConnectionTest.php
+++ b/tests/Gateway/ConnectionTest.php
@@ -492,7 +492,7 @@ class ConnectionTest extends MockeryTestCase
         /** @var MessageInterface&MockInterface */
         $message = Mockery::mock(MessageInterface::class);
         $message->expects()
-            ->__toString()
+            ->getPayload()
             ->andReturns('{"op": 1}')
             ->once();
 

--- a/tests/Gateway/ConnectionTest.php
+++ b/tests/Gateway/ConnectionTest.php
@@ -80,7 +80,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->expects()
             ->open()
-            ->with('::ws url::?v=10')
+            ->with('::ws url::?' . http_build_query(Connection::QUERY_DATA))
             ->andReturns(PromiseFake::get('::return::'))
             ->once();
 
@@ -556,7 +556,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->emit(WebsocketEvents::CLOSE, [$code, 'reason']);
 
-        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?v=' . Connection::DISCORD_VERSION], $websocket->openings);
+        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?' . http_build_query(Connection::QUERY_DATA)], $websocket->openings);
     }
 
     public static function reconnectCloseCodesProvider(): array
@@ -606,7 +606,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->emit(WebsocketEvents::CLOSE, [$code, 'reason']);
 
-        $this->assertEquals(['::resume url::?v=' . Connection::DISCORD_VERSION], $websocket->openings);
+        $this->assertEquals(['::resume url::?' . http_build_query(Connection::QUERY_DATA)], $websocket->openings);
     }
 
     /**
@@ -641,7 +641,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->emit(WebsocketEvents::CLOSE, [$code, 'reason']);
 
-        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?v=' . Connection::DISCORD_VERSION], $websocket->openings);
+        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?' . http_build_query(Connection::QUERY_DATA)], $websocket->openings);
     }
 
     /**
@@ -676,7 +676,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->emit(WebsocketEvents::CLOSE, [$code, 'reason']);
 
-        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?v=' . Connection::DISCORD_VERSION], $websocket->openings);
+        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?' . http_build_query(Connection::QUERY_DATA)], $websocket->openings);
     }
 
     public static function resumeCloseCodesProvider(): array

--- a/tests/Gateway/ConnectionTest.php
+++ b/tests/Gateway/ConnectionTest.php
@@ -35,6 +35,12 @@ use function React\Async\await;
 
 class ConnectionTest extends MockeryTestCase
 {
+    private const EXPECTED_QUERY_PARAMS = [
+        'v' => 10,
+        'encoding' => 'json',
+        'compress' => 'zlib-stream'
+    ];
+
     public function testGetDefaultUrl(): void
     {
         $connection = new Connection(
@@ -80,7 +86,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->expects()
             ->open()
-            ->with('::ws url::?' . http_build_query(Connection::QUERY_DATA))
+            ->with('::ws url::?' . http_build_query(self::EXPECTED_QUERY_PARAMS))
             ->andReturns(PromiseFake::get('::return::'))
             ->once();
 
@@ -556,7 +562,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->emit(WebsocketEvents::CLOSE, [$code, 'reason']);
 
-        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?' . http_build_query(Connection::QUERY_DATA)], $websocket->openings);
+        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?' . http_build_query(self::EXPECTED_QUERY_PARAMS)], $websocket->openings);
     }
 
     public static function reconnectCloseCodesProvider(): array
@@ -606,7 +612,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->emit(WebsocketEvents::CLOSE, [$code, 'reason']);
 
-        $this->assertEquals(['::resume url::?' . http_build_query(Connection::QUERY_DATA)], $websocket->openings);
+        $this->assertEquals(['::resume url::?' . http_build_query(self::EXPECTED_QUERY_PARAMS)], $websocket->openings);
     }
 
     /**
@@ -641,7 +647,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->emit(WebsocketEvents::CLOSE, [$code, 'reason']);
 
-        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?' . http_build_query(Connection::QUERY_DATA)], $websocket->openings);
+        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?' . http_build_query(self::EXPECTED_QUERY_PARAMS)], $websocket->openings);
     }
 
     /**
@@ -676,7 +682,7 @@ class ConnectionTest extends MockeryTestCase
 
         $websocket->emit(WebsocketEvents::CLOSE, [$code, 'reason']);
 
-        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?' . http_build_query(Connection::QUERY_DATA)], $websocket->openings);
+        $this->assertEquals([Connection::DEFAULT_WEBSOCKET_URL . '?' . http_build_query(self::EXPECTED_QUERY_PARAMS)], $websocket->openings);
     }
 
     public static function resumeCloseCodesProvider(): array


### PR DESCRIPTION
Implemented zlib compression support. However, the current logging behavior is not fully understood — log messages may not appear correctly. This may be due to the logging process occurring before decompression, and relocating it post-decompression could potentially resolve the issue.

Additionally, an issue was identified where a shard would throw error 1003 on startup and immediately reboot. This was resolved by deferring the execution using futureTick().

This commit does not resolve the underlying issue with mass shard reboots. However, while working on it, I inadvertently introduced a mistake that caused a "ZLIB decompression error" during shard restarts. Unexpectedly, this led to the shard rebooting cleanly and without system load, which resembled the intended behavior. Although this was not an intentional change and is unrelated to the actual modifications, the behavior observed in the logic executed after this error may point to the correct direction and should be taken into account in future debugging efforts.