### PR TITLE
Send permission bit fields as decimal, not binary

### DIFF
--- a/src/Rest/Helpers/Channel/EditPermissionsBuilder.php
+++ b/src/Rest/Helpers/Channel/EditPermissionsBuilder.php
@@ -37,7 +37,7 @@ class EditPermissionsBuilder
 
     public function setAllow(Bitwise $allow): self
     {
-        $this->data['allow'] = $allow->getBitSet();
+        $this->data['allow'] = (string) $allow->get();
 
         return $this;
     }
@@ -45,13 +45,13 @@ class EditPermissionsBuilder
     public function getAllow(): ?Bitwise
     {
         return isset($this->data['allow'])
-            ? Bitwise::fromBitSet($this->data['allow'])
+            ? new Bitwise((int) $this->data['allow'])
             : null;
     }
 
     public function setDeny(Bitwise $deny): self
     {
-        $this->data['deny'] = $deny->getBitSet();
+        $this->data['deny'] = (string) $deny->get();
 
         return $this;
     }
@@ -59,7 +59,7 @@ class EditPermissionsBuilder
     public function getDeny(): ?Bitwise
     {
         return isset($this->data['deny'])
-            ? Bitwise::fromBitSet($this->data['deny'])
+            ? new Bitwise((int) $this->data['deny'])
             : null;
     }
 

--- a/src/Rest/Helpers/Command/CommandBuilder.php
+++ b/src/Rest/Helpers/Command/CommandBuilder.php
@@ -134,7 +134,7 @@ class CommandBuilder
      */
     public function setDefaultMemberPermissions(Bitwise $permissions): self
     {
-        $this->data['default_member_permissions'] = $permissions->getBitSet();
+        $this->data['default_member_permissions'] = (string) $permissions->get();
 
         return $this;
     }
@@ -145,7 +145,7 @@ class CommandBuilder
     public function getDefaultMemberPermissions(): ?Bitwise
     {
         return isset($this->data['default_member_permissions'])
-            ? Bitwise::fromBitSet($this->data['default_member_permissions'])
+            ? new Bitwise((int) $this->data['default_member_permissions'])
             : null;
     }
 

--- a/tests/Rest/Helpers/Channel/EditPermissionsBuilderTest.php
+++ b/tests/Rest/Helpers/Channel/EditPermissionsBuilderTest.php
@@ -39,7 +39,7 @@ class EditPermissionsBuilderTest extends TestCase
 
         $this->assertNull($builder->getAllow());
 
-        $bitwise = new Bitwise(
+        $bitwise = Bitwise::from(
             1 << 1,
             1 << 2,
             1 << 3
@@ -48,6 +48,7 @@ class EditPermissionsBuilderTest extends TestCase
         $builder->setAllow($bitwise);
 
         $this->assertEquals($bitwise->get(), $builder->getAllow()->get());
+        $this->assertSame('14', $builder->get()['allow']);
     }
 
     public function testSetDeny(): void
@@ -56,7 +57,7 @@ class EditPermissionsBuilderTest extends TestCase
 
         $this->assertNull($builder->getDeny());
 
-        $bitwise = new Bitwise(
+        $bitwise = Bitwise::from(
             1 << 1,
             1 << 2,
             1 << 3
@@ -65,5 +66,11 @@ class EditPermissionsBuilderTest extends TestCase
         $builder->setDeny($bitwise);
 
         $this->assertEquals($bitwise->get(), $builder->getDeny()->get());
+
+        /*
+         * A decimal bit field, as Discord reads it; the binary representation
+         * would be read back as a different set of permissions.
+         */
+        $this->assertSame('14', $builder->get()['deny']);
     }
 }

--- a/tests/Rest/Helpers/Command/CommandBuilderTest.php
+++ b/tests/Rest/Helpers/Command/CommandBuilderTest.php
@@ -92,7 +92,13 @@ class CommandBuilderTest extends TestCase
         $commandBuilder->setDefaultMemberPermissions($permissions);
 
         $this->assertEquals($permissions->get(), $commandBuilder->getDefaultMemberPermissions()->get());
-        $this->assertEquals($permissions->getBitSet(), $commandBuilder->get()['default_member_permissions']);
+
+        /*
+         * Discord reads this as a decimal bit field. Sending the binary
+         * representation would be read back as an entirely different, and
+         * much larger, set of permissions.
+         */
+        $this->assertSame('6', $commandBuilder->get()['default_member_permissions']);
     }
 
     public function testSetDmPermission(): void


### PR DESCRIPTION
## The bug

`Bitwise::getBitSet()` returns `decbin()`, and three payloads send its result straight to Discord:

- `CommandBuilder::setDefaultMemberPermissions()` → `default_member_permissions`
- `EditPermissionsBuilder::setAllow()` → `allow`
- `EditPermissionsBuilder::setDeny()` → `deny`

Discord reads all three as **decimal**. So asking for `ADMINISTRATOR`, which is `1 << 3`, sends `"1000"` — and Discord reads that as one thousand:

```php
$b = Bitwise::from(Permission::ADMINISTRATOR);

$b->get();        // 8   — what you asked for
$b->getBitSet();  // "1000" — what was sent
(int) "1000";     // 1000 — what Discord stores
```

Decimal 1000 is `ADMINISTRATOR | MANAGE_GUILD | ADD_REACTIONS | VIEW_AUDIT_LOG | PRIORITY_SPEAKER | STREAM`.

Every command registered with default permissions has been granting five permissions nobody asked for, and channel permission overwrites have been allowing and denying the wrong things.

## The fix

All three send the decimal value, and the matching getters read it back the same way rather than through `fromBitSet`.

`getBitSet()` itself is untouched — a binary representation is a reasonable thing to expose and it has its own test. It just isn't what goes on the wire.

## Why it survived

The test asserted the payload equalled `getBitSet()`:

```php
$this->assertEquals($permissions->getBitSet(), $commandBuilder->get()['default_member_permissions']);
```

That describes the behaviour rather than the requirement, so it passed either way. Both tests now assert the literal value Discord expects.

While there: `EditPermissionsBuilderTest` built its Bitwise with `new Bitwise(1 << 1, 1 << 2, 1 << 3)`. The constructor takes a single int, so the second and third arguments were silently dropped and the test only ever exercised one flag. It now uses `Bitwise::from`.

## Notes

This is split out of #133 deliberately — it's a small correctness fix against `master` that stands on its own and is worth releasing without waiting on that larger branch. #133 contains this same commit; whichever merges first, the other rebases cleanly.

`composer test` (526), `composer cs` and `util/verify-namespacing.sh` all pass.
